### PR TITLE
Mark forms created for links with data-turbo-method as hidden

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -146,6 +146,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
       const form = document.createElement("form")
       form.method = linkMethod
       form.action = link.getAttribute("href") || "undefined"
+      form.hidden = true
 
       link.parentNode?.insertBefore(form, link)
       return dispatch("submit", { cancelable: true, target: form })


### PR DESCRIPTION
I have an example of some styles breaking when a form is injected into the markup.

https://user-images.githubusercontent.com/77887/134426025-fca17045-9c33-4a42-9f3e-c90bdba39360.mp4

You can see the actions move to the right after clicking the "Undo" link. This is because the actions are spaced out using [TailwindCSS's spacing helpers](https://tailwindcss.com/docs/space), and the link has a `data-turbo-method` attribute which causes Turbo to create a form and insert it in the DOM before the link. So where there was previously:

```html
<div class="space-x-3">
  <a data-turbo-method="delete" href="...">Undo</a>
  <a>Dismiss</a>
</div>
```

I now have:

```html
<div class="space-x-3">
  <form>...</form> <!-- Spacing is being added unintentionally now due to this new element -->
  <a data-turbo-method="delete" href="...">Undo</a>
  <a>Dismiss</a>
</div>
```

---

One possible solution would be to use the [`hidden` global attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden) to indicate that the form is not meant for display. Conveniently, the TailwindCSS spacing helpers already ignore elements marked as hidden when applying spacing. Here is the same scenario as above, same DOM and CSS, but with the form's `hidden` attribute set.

https://user-images.githubusercontent.com/77887/134427219-1fa4f284-1f8b-4f40-80d2-7468c08d5406.mp4

Thanks for your time in reviewing this!